### PR TITLE
Add deprecation notice to the repo's README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,6 @@
+# DEPRECATION NOTICE
+This repository is no longer active. Creation of new Datadog integrations should follow the official [documentation pages](https://docs.datadoghq.com/developers/integrations/new_check_howto/?tab=configurationtemplate)
+
 # Datadog Integration Tile Template
 
 This repository is meant to help create tiles for Integrations which do *not* contain Python checks. Any Integrations which contain Python code - typically those that are run via the Agent - should use the [standard tooling][1] for generating tile templates.

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # DEPRECATION NOTICE
-This repository is no longer active. Creation of new Datadog integrations should follow the official [documentation pages](https://docs.datadoghq.com/developers/integrations/new_check_howto/?tab=configurationtemplate)
+This repository is no longer active. Creation of new Datadog integrations should follow the instructions laid out in the [integration documentation](https://docs.datadoghq.com/developers/integrations/new_check_howto/?tab=configurationtemplate).
 
 # Datadog Integration Tile Template
 


### PR DESCRIPTION
This repository is out of date with the current approaches and tooling for creating new Datadog integrations and checks. Additionally, PRs for new integrations shouldn't be made to this repository. Integration developers should follow the processes outlined here - https://docs.datadoghq.com/developers/integrations/new_check_howto/?tab=configurationtemplate instead. 